### PR TITLE
Bug Fix: Refresh state on disconnect wallet account 

### DIFF
--- a/src/components/Navbar/components/ButtonConnectWallet.tsx
+++ b/src/components/Navbar/components/ButtonConnectWallet.tsx
@@ -11,6 +11,7 @@ export function ButtonConnectWallet() {
   const handleOnClick = async () => {
     if (walletSelector.selector.isSignedIn() && walletSelector.wallet) {
       walletSelector.wallet.signOut();
+      window.location.reload() // to update the active game state
     } else {
       walletSelector.modal.show();
     }


### PR DESCRIPTION
I tried using Global context and props to pass down state and update it, but there are multiple states initiated in multiple components, so the best way is to reload the page